### PR TITLE
Delegate registration fees updated

### DIFF
--- a/src/constants/fees.js
+++ b/src/constants/fees.js
@@ -1,6 +1,6 @@
 export default {
   setSecondPassphrase: 0.1e8,
   send: 0.1e8,
-  registerDelegate: 25e8,
+  registerDelegate: 5e8,
   vote: 1e8,
 };


### PR DESCRIPTION
Oxy Delegate Registration fees were set to 25 Oxy which is currently not true as it's 5 Oxy per delegate registration